### PR TITLE
Add java.sql.Driver so we are JDBC 4.0 compliant

### DIFF
--- a/src/main/resources/META-INF/services/java.sql.Driver
+++ b/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+net.sf.log4jdbc.DriverSpy


### PR DESCRIPTION
When this file is in the jar, JBoss 7.1 and its successor WIldfly 8.2.1 will load the Log4Jdbc driver. Without it, they don't recognise it as a JDBC driver.
